### PR TITLE
set pandoc version

### DIFF
--- a/envs/environment_R.yaml
+++ b/envs/environment_R.yaml
@@ -2,4 +2,4 @@ channels:
 - conda-forge
 dependencies:
 - r-base=4.0.2
-- pandoc
+- pandoc=2.10


### PR DESCRIPTION
Version 2.11 of pandoc is no longer ported with pandoc-citeproc in conda. See the deprecation warning here: https://github.com/jgm/pandoc-citeproc. 

This breaks the test in [generate_report.R](https://github.com/csoneson/ARMOR/blob/875e18a0919c5e92d91431533acc0b93de6faba9/scripts/generate_report.R#L87), and is no longer compatible with rmarkdown [see issue](https://github.com/rstudio/rmarkdown/issues/1915). 

Until rmarkdown is fixed, setting the version number to 2.10 is the easiest solution.